### PR TITLE
Update snapshot logic to avoid unnecessary overwrites

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -26,16 +26,15 @@ async function toMatchSvgSnapshot(
     process.argv.includes("--update-snapshots") ||
     process.argv.includes("-u") ||
     Boolean(process.env["BUN_UPDATE_SNAPSHOTS"])
+  const forceUpdate = Boolean(process.env["FORCE_BUN_UPDATE_SNAPSHOTS"])
 
-  if (!fs.existsSync(filePath) || updateSnapshot) {
-    if (updateSnapshot && fs.existsSync(filePath)) {
-      console.log("Updating snapshot at", filePath)
-    } else {
-      console.log("Writing snapshot to", filePath)
-    }
+  const fileExists = fs.existsSync(filePath)
+
+  if (!fileExists) {
+    console.log("Writing snapshot to", filePath)
     fs.writeFileSync(filePath, received)
     return {
-      message: () => `Snapshot ${updateSnapshot ? 'updated' : 'created'} at ${filePath}`,
+      message: () => `Snapshot created at ${filePath}`,
       pass: true,
     }
   }
@@ -50,6 +49,21 @@ async function toMatchSvgSnapshot(
       tolerance: 2,
     },
   )
+
+  if (updateSnapshot) {
+    if (!forceUpdate && result.equal) {
+      return {
+        message: () => "Snapshot matches",
+        pass: true,
+      }
+    }
+    console.log("Updating snapshot at", filePath)
+    fs.writeFileSync(filePath, received)
+    return {
+      message: () => `Snapshot updated at ${filePath}`,
+      pass: true,
+    }
+  }
 
   if (result.equal) {
     return {
@@ -99,16 +113,15 @@ async function toMatchMultipleSvgSnapshots(
       process.argv.includes("--update-snapshots") ||
       process.argv.includes("-u") ||
       Boolean(process.env["BUN_UPDATE_SNAPSHOTS"])
+    const forceUpdate = Boolean(process.env["FORCE_BUN_UPDATE_SNAPSHOTS"])
 
-    if (!fs.existsSync(filePath) || updateSnapshot) {
-      if (updateSnapshot && fs.existsSync(filePath)) {
-        console.log("Updating snapshot at", filePath)
-      } else {
-        console.log("Writing snapshot to", filePath)
-      }
+    const fileExists = fs.existsSync(filePath)
+
+    if (!fileExists) {
+      console.log("Writing snapshot to", filePath)
       fs.writeFileSync(filePath, received[index] as any)
       passed.push({
-        message: `Snapshot ${svgName} ${updateSnapshot ? 'updated' : 'created'} at ${filePath}`,
+        message: `Snapshot ${svgName} created at ${filePath}`,
         pass: true,
       })
       continue
@@ -124,6 +137,23 @@ async function toMatchMultipleSvgSnapshots(
         tolerance: 2,
       },
     )
+
+    if (updateSnapshot) {
+      if (!forceUpdate && result.equal) {
+        passed.push({
+          message: `Snapshot ${svgName} matches`,
+          pass: true,
+        })
+        continue
+      }
+      console.log("Updating snapshot at", filePath)
+      fs.writeFileSync(filePath, received[index] as any)
+      passed.push({
+        message: `Snapshot ${svgName} updated at ${filePath}`,
+        pass: true,
+      })
+      continue
+    }
 
     if (result.equal) {
       passed.push({

--- a/tests/toMatchSvgSnapshot.test.ts
+++ b/tests/toMatchSvgSnapshot.test.ts
@@ -9,6 +9,7 @@ const testSvg = `<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg
 
 const snapshotDir = path.join(__dirname, "__snapshots__")
 const snapshotPath = path.join(snapshotDir, "test.snap.svg")
+const metadataSnapshotPath = path.join(snapshotDir, "metadata.snap.svg")
 
 beforeAll(() => {
   if (!fs.existsSync(snapshotDir)) {
@@ -19,6 +20,9 @@ beforeAll(() => {
 afterAll(() => {
   if (fs.existsSync(snapshotPath)) {
     fs.unlinkSync(snapshotPath)
+  }
+  if (fs.existsSync(metadataSnapshotPath)) {
+    fs.unlinkSync(metadataSnapshotPath)
   }
   if (fs.existsSync(snapshotDir)) {
     fs.rmdirSync(snapshotDir, { recursive: true })
@@ -34,6 +38,20 @@ test("toMatchSvgSnapshot creates and matches snapshot", async () => {
 
   // Second run: match existing snapshot
   await expect(testSvg).toMatchSvgSnapshot(import.meta.path, "test")
+})
+
+test("does not update snapshot when visually identical", async () => {
+  const svgWithComment = `<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+  <!-- comment -->
+  <circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red" />
+</svg>`
+
+  await expect(testSvg).toMatchSvgSnapshot(import.meta.path, "metadata")
+  const original = fs.readFileSync(metadataSnapshotPath, "utf-8")
+
+  await expect(svgWithComment).toMatchSvgSnapshot(import.meta.path, "metadata")
+  const updated = fs.readFileSync(metadataSnapshotPath, "utf-8")
+  expect(updated).toBe(original)
 })
 
 // test("toMatchSvgSnapshot detects differences", async () => {


### PR DESCRIPTION
## Summary
- update snapshot functions to only write new files when images differ or when `FORCE_BUN_UPDATE_SNAPSHOTS` is set
- add regression test ensuring identical SVGs don't rewrite snapshots

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests`

------
https://chatgpt.com/codex/tasks/task_b_686d45e8fb50832e90dc3ec35dffa036