### PR TITLE
Prefix snapshot names with test file base

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -14,7 +14,7 @@ async function toMatchSvgSnapshot(
   const testPath = testPathOriginal.replace(/\.test\.tsx?$/, "")
   const snapshotDir = path.join(path.dirname(testPath), "__snapshots__")
   const snapshotName = svgName
-    ? `${svgName}.snap.svg`
+    ? `${path.basename(testPath)}-${svgName}.snap.svg`
     : `${path.basename(testPath)}.snap.svg`
   const filePath = path.join(snapshotDir, snapshotName)
 
@@ -101,7 +101,7 @@ async function toMatchMultipleSvgSnapshots(
     const testPath = testPathOriginal.replace(/\.test\.tsx?$/, "")
     const snapshotDir = path.join(path.dirname(testPath), "__snapshots__")
     const snapshotName = svgName
-      ? `${svgName}.snap.svg`
+      ? `${path.basename(testPath)}-${svgName}.snap.svg`
       : `${path.basename(testPath)}.snap.svg`
     const filePath = path.join(snapshotDir, snapshotName)
 

--- a/tests/toMatchMultipleSvgSnapshots.test.ts
+++ b/tests/toMatchMultipleSvgSnapshots.test.ts
@@ -25,9 +25,10 @@ const testSvgs = [
 const svgNames: string[] = []
 for (let i = 0; i < testSvgs.length; i++) svgNames.push(`test${i + 1}`)
 
+const testPathBase = path.basename(import.meta.path.replace(/\.test\.tsx?$/, ""))
 const snapshotDir = path.join(__dirname, "__snapshots__")
 const snapshotPaths = svgNames.map((svgName) =>
-  path.join(snapshotDir, `${svgName}.snap.svg`),
+  path.join(snapshotDir, `${testPathBase}-${svgName}.snap.svg`),
 )
 
 beforeAll(() => {

--- a/tests/toMatchSvgSnapshot.test.ts
+++ b/tests/toMatchSvgSnapshot.test.ts
@@ -7,9 +7,13 @@ const testSvg = `<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg
   <circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red" />
 </svg>`
 
+const testPathBase = path.basename(import.meta.path.replace(/\.test\.tsx?$/, ""))
 const snapshotDir = path.join(__dirname, "__snapshots__")
-const snapshotPath = path.join(snapshotDir, "test.snap.svg")
-const metadataSnapshotPath = path.join(snapshotDir, "metadata.snap.svg")
+const snapshotPath = path.join(snapshotDir, `${testPathBase}-test.snap.svg`)
+const metadataSnapshotPath = path.join(
+  snapshotDir,
+  `${testPathBase}-metadata.snap.svg`,
+)
 
 beforeAll(() => {
   if (!fs.existsSync(snapshotDir)) {


### PR DESCRIPTION
## Summary
- include the originating test file name when building SVG snapshot filenames
- update snapshot-related tests to expect the new naming convention

## Testing
- bunx tsc --noEmit
- BUN_UPDATE_SNAPSHOTS=1 bun test


------
https://chatgpt.com/codex/tasks/task_b_68dcc7f0f208832e8d4429a154cdeb48